### PR TITLE
feat(attachment): bind interface to implementation for class Attachment

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Storage;
 use Symfony\Component\HttpFoundation\File\File as FileObj;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Bnb\Laravel\Attachments\Contracts\AttachmentContract;
 
 /**
  * @property int    id
@@ -32,7 +33,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  *
  * @package   Bnb\Laravel\Attachments
  */
-class Attachment extends Model
+class Attachment extends Model implements AttachmentContract
 {
 
     protected $table = 'attachments';

--- a/src/AttachmentsServiceProvider.php
+++ b/src/AttachmentsServiceProvider.php
@@ -44,5 +44,11 @@ class AttachmentsServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/attachments.php', 'attachments');
+
+        // Bind Model to Interface
+        $this->app->bind(
+            \Bnb\Laravel\Attachments\Contracts\AttachmentContract::class,
+            \Bnb\Laravel\Attachments\Attachment::class
+        );
     }
 }

--- a/src/Console/Commands/CleanupAttachments.php
+++ b/src/Console/Commands/CleanupAttachments.php
@@ -8,7 +8,7 @@
 
 namespace Bnb\Laravel\Attachments\Console\Commands;
 
-use Bnb\Laravel\Attachments\Attachment;
+use Bnb\Laravel\Attachments\Contracts\AttachmentContract;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
@@ -17,25 +17,33 @@ use Symfony\Component\Console\Input\InputOption;
 
 class CleanupAttachments extends Command
 {
+    /**
+     * Attachment model
+     *
+     * @var AttachmentContract
+     */
+    protected $model;
 
     protected $signature = 'attachments:cleanup';
 
-
-    public function __construct()
+    public function __construct(AttachmentContract $model)
     {
         parent::__construct();
+
+        $this->model = $model;
 
         $this->setDescription(Lang::get('attachments::messages.console.cleanup_description'));
 
         $this->getDefinition()->addOption(new InputOption('since', '-s', InputOption::VALUE_OPTIONAL,
-            Lang::get('attachments::messages.console.cleanup_option_since'), 1440));
+
+        Lang::get('attachments::messages.console.cleanup_option_since'), 1440));
     }
 
 
     public function handle()
     {
         if ($this->confirm(Lang::get('attachments::messages.console.cleanup_confirm'))) {
-            $query = Attachment::query()
+            $query = $this->model
                 ->whereNull('model_type')
                 ->whereNull('model_id')
                 ->where('updated_at', '<=', Carbon::now()->addMinutes(-1 * $this->option('since')));
@@ -46,7 +54,7 @@ class CleanupAttachments extends Command
                 $query->chunk(100, function ($attachments) use ($progress) {
                     /** @var Collection $attachments */
                     $attachments->each(function ($attachment) use ($progress) {
-                        /** @var Attachment $attachment */
+                        /** @var AttachmentContract $attachment */
                         $attachment->delete();
 
                         $progress->advance();

--- a/src/Contracts/AttachmentContract.php
+++ b/src/Contracts/AttachmentContract.php
@@ -1,0 +1,7 @@
+<?php
+namespace Bnb\Laravel\Attachments\Contracts;
+
+interface AttachmentContract
+{
+
+}

--- a/src/Http/Controllers/DownloadController.php
+++ b/src/Http/Controllers/DownloadController.php
@@ -3,18 +3,30 @@
 namespace Bnb\Laravel\Attachments\Http\Controllers;
 
 use Bnb\Laravel\Attachments\Attachment;
+use Bnb\Laravel\Attachments\Contracts\AttachmentContract;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Lang;
 
 class DownloadController extends Controller
 {
+    /**
+     * Attachment model
+     *
+     * @var AttachmentContract
+     */
+    protected $model;
+
+    public function __construct(AttachmentContract $model)
+    {
+        $this->model = $model;
+    }
 
     public function download($id, Request $request)
     {
         $disposition = ($disposition = $request->input('disposition')) === 'inline' ? $disposition : 'attachment';
 
-        if ($file = Attachment::where('uuid', $id)->first()) {
+        if ($file = $this->model->where('uuid', $id)->first()) {
             /** @var Attachment $file */
             if ( ! $file->output($disposition)) {
                 abort(403, Lang::get('attachments::messages.errors.access_denied'));

--- a/src/Http/Controllers/ShareController.php
+++ b/src/Http/Controllers/ShareController.php
@@ -2,16 +2,27 @@
 
 namespace Bnb\Laravel\Attachments\Http\Controllers;
 
-use Bnb\Laravel\Attachments\Attachment;
+use Bnb\Laravel\Attachments\Contracts\AttachmentContract;
 use Carbon\Carbon;
+use Crypt;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Lang;
-use Crypt;
 
 class ShareController extends Controller
 {
+    /**
+     * Attachment model
+     *
+     * @var AttachmentContract
+     */
+    protected $model;
+
+    public function __construct(AttachmentContract $model)
+    {
+        $this->model = $model;
+    }
 
     public function download($token, Request $request)
     {
@@ -32,8 +43,8 @@ class ShareController extends Controller
 
         $disposition = ($disposition = $request->input('disposition')) === 'inline' ? $disposition : 'attachment';
 
-        if ($file = Attachment::where('uuid', $id)->first()) {
-            /** @var Attachment $file */
+        if ($file = $this->model->where('uuid', $id)->first()) {
+            /** @var AttachmentContract $file */
             if ( ! $file->output($disposition)) {
                 abort(403, Lang::get('attachments::messages.errors.access_denied'));
             }


### PR DESCRIPTION
On this way, the developer could inherit the Attachment class and add relations into this new class.
This can be helpfull if you want add some relations to attachment model

eg:

_File: `models/MyAttachment.php`_
```php
<?php
namespace MyProject\Models;

MyAttachment extends Bnb\Laravel\Attachments\Attachment
{
    public function someCustomRelation() {}
}

```

_File: `MyServiceProvider.php`_
```php
<?php

    public function register()
    {
        parent::register();
        
        $this->app->bind(
            \Bnb\Laravel\Attachments\Contracts\AttachmentContract::class,
            \MyProject\Models\MyAttachment::class
        );
    }
```