### PR TITLE
Added soft deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Calling the `delete()` method on an attachment model instance will
  be disabled by setting the `behaviors.cascade_delete` to `false` in
  the configuration.
 
-> Not that calling `delete()` on a `query()` like statement will not
+> Note that calling `delete()` on a `query()` like statement will not
  cascade to the filesystem because it will not call the `delete()`
  method of the `Attachment` model class.
 
@@ -133,6 +133,15 @@ $user = App\User::first();
 $attachmentByKey = $user->attachment('myKey');
 $attachmentByKey->delete(); // Will also delete the file on the storage by default
 ```
+
+### Soft Deletes
+The package also supports the Laravel's SoftDeletes trait (disabled by default).
+ It can be enabled by setting the `behaviors.soft_delete` to `true` in
+ the configuration.
+
+> Note that `behaviors.cascade_delete` setting will then work only with
+ the `forceDelete()` method of the `Attachment` model class.
+ All the files will be kept while the record is soft-deleted
 
 
 ## Hooking the file output

--- a/config/attachments.php
+++ b/config/attachments.php
@@ -56,6 +56,7 @@ return [
     */
     'behaviors' => [
         'cascade_delete' => env('ATTACHMENTS_CASCADE_DELETE', true),
+        'soft_delete' => env('ATTACHMENTS_SOFT_DELETE', false),
         'dropzone_check_csrf' => env('ATTACHMENTS_DROPZONE_CHECK_CSRF', true),
     ],
 

--- a/migrations/2024_12_23_100100_alter_attachments_table_add_deleted_at_column.php
+++ b/migrations/2024_12_23_100100_alter_attachments_table_add_deleted_at_column.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterAttachmentsTableAddDeletedAtColumn extends Migration
+{
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::hasTable('attachments')) {
+            Schema::table('attachments', function (Blueprint $table) {
+                $table->softDeletes();
+            });
+        }
+    }
+
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::hasTable('attachments')) {
+            Schema::table('attachments', function (Blueprint $table) {
+                $table->dropColumn('deleted_at');
+            });
+        }
+    }
+}

--- a/src/Console/Commands/CleanupAttachments.php
+++ b/src/Console/Commands/CleanupAttachments.php
@@ -44,6 +44,7 @@ class CleanupAttachments extends Command
     {
         if ($this->confirm(Lang::get('attachments::messages.console.cleanup_confirm'))) {
             $query = $this->model
+                ->withTrashed()
                 ->whereNull('model_type')
                 ->whereNull('model_id')
                 ->where('updated_at', '<=', Carbon::now()->addMinutes(-1 * $this->option('since')));
@@ -55,7 +56,7 @@ class CleanupAttachments extends Command
                     /** @var Collection $attachments */
                     $attachments->each(function ($attachment) use ($progress) {
                         /** @var AttachmentContract $attachment */
-                        $attachment->delete();
+                        $attachment->forceDelete();
 
                         $progress->advance();
                     });

--- a/src/Console/Commands/MigrateAttachments.php
+++ b/src/Console/Commands/MigrateAttachments.php
@@ -78,7 +78,7 @@ class MigrateAttachments extends Command
             $this->error(Lang::get('attachments::messages.console.migrate_invalid_to'));
         }
 
-        $query = Attachment::query()
+        $query = Attachment::withTrashed()
             ->where('disk', '=', $this->argument('from'));
 
         $this

--- a/src/Http/Controllers/DropzoneController.php
+++ b/src/Http/Controllers/DropzoneController.php
@@ -74,7 +74,7 @@ class DropzoneController extends Controller
                     return response(Lang::get('attachments::messages.errors.delete_denied'), 403);
                 }
 
-                $file->delete();
+                $file->forceDelete();
             }
 
             return response('', 204);


### PR DESCRIPTION
Added Laravel's builtin soft deletes to Attachment model.
The feature is optionally enableable by changing the config `behaviors.soft_delete`. 
It's retro-compatible and by default maintains the behaviour of older package versions.